### PR TITLE
Feat/iteration1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   faraday

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # The DMV
 
 This is the starter repo for the BE Mod1 DMV project.
+

--- a/lib/dmv.rb
+++ b/lib/dmv.rb
@@ -1,4 +1,6 @@
 class Dmv
+  attr_reader :facilities
+
 
   def initialize
     @facilities = []
@@ -9,7 +11,7 @@ class Dmv
   end
 
   def facilities_offering_service(service)
-    @facilities.find do |facility|
+    @facilities.find_all do |facility|
       facility.services.include?(service)
     end
   end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,14 +1,14 @@
 class Facility
   attr_reader :name, :address, :phone, :services
 
-  def initialize(name, address, phone)
-    @name = name
-    @address = address
-    @phone = phone
+  def initialize(fac_info)
+    @name = fac_info[:name]
+    @address = fac_info[:address]
+    @phone = fac_info[:phone]
     @services = []
   end
 
-  def add_services(service)
+  def add_service(service)
     @services << service
   end
 end

--- a/lib/registrant.rb
+++ b/lib/registrant.rb
@@ -1,0 +1,15 @@
+class Registrant
+    attr_reader :name,
+                :age,
+                :permit,
+                :license_data
+
+    def initialize(name, age, permit = false)
+        @name = name
+        @age = age
+        @permit = permit
+        @license_data = {:written=>false, :license=>false, :renewed=>false}
+    end
+
+    
+end

--- a/lib/registrant.rb
+++ b/lib/registrant.rb
@@ -11,5 +11,15 @@ class Registrant
         @license_data = {:written=>false, :license=>false, :renewed=>false}
     end
 
-    
+    def earn_permit
+        if @permit == false
+            @permit = true
+        else 
+            "Permit is already earned"
+        end
+    end
+
+    def permit?
+        @permit
+    end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -5,7 +5,8 @@ class Vehicle
               :year,
               :make,
               :model,
-              :engine
+              :engine,
+              :registration_date
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]
@@ -13,6 +14,7 @@ class Vehicle
     @make = vehicle_details[:make]
     @model = vehicle_details[:model]
     @engine = vehicle_details[:engine]
+    @registration_date = nil
   end
 
   def antique?

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -1,0 +1,60 @@
+require 'rspec'
+require './lib/registrant'
+
+
+RSpec.configure do |config|
+    config.formatter = :documentation
+    end
+
+RSpec.describe 'registrant' do
+
+    before(:each) do
+        @registrant_1 = Registrant.new('Bruce', 18, true )
+        @registrant_2 = Registrant.new('Penny', 15 )
+    end
+
+    describe '#initialize' do
+        it 'should exist' do
+            expect(@registrant_1).to be_an_instance_of Registrant
+        end
+
+        it 'should have a name' do
+            expect(@registrant_1.name).to eq 'Bruce'
+        end
+
+        it 'should have an age' do
+            expect(@registrant_1.age).to eq 18
+        end
+
+        it 'should default to not have a permit' do
+            expect(@registrant_2.permit).to be false
+        end
+
+        it 'should be able to have a permit if specificed' do
+            expect(@registrant_1.permit).to be true
+        end
+
+        it 'should default to have license data without any true values' do
+            expect(@registrant_1.license_data).to include({:written => false, :license => false, :renewed => false})
+        end
+    end
+
+    describe '#earn_permit' do
+        it 'should update the permit atttribute' do
+            expect(@registrant_2.permit).to be false
+            @registrant_2.earn_permit
+
+            expect(@registrant_2.permit).to be true
+        end
+
+        it 'should be inaccesable to someone who has already earned their permit' do
+            expect(@registrant_1.earn_permit).to eq "Permit is already earned"
+        end
+    end
+
+    describe '#permit?' do
+        it 'should return wether or not individual has a permit' do
+            expect(@registrant_1.permit?).to be true
+        end
+    end
+end


### PR DESCRIPTION
- Fix bugs present in prewritten implementation files for dmv and facility implementations
    - condense facility `#initialize` params from 3 into one hash
    - swap to `final_all` enum in `#facilities_offering_service` method
- Write spec and implementation for Registration class.
    - `#initialize` 
        - will instantiate unit with name, age and permit (default set to `false`) params 
        - initializes license_data hash set to `{:written=>false, :license=>false, :renewed=>false}`
    - `#earn_permit`
        - method to update `permit` attribute's boolean IF currently set to false
        - ELSE permit value will not change & it will return string `"Permit is already earned"`
    - `#permit?`
        - boolean to return status of `permit` attribute 